### PR TITLE
Fix typos: "reponse" -> "response" and "formated" -> "formatted"

### DIFF
--- a/apps/web/src/db/supabase-queries.ts
+++ b/apps/web/src/db/supabase-queries.ts
@@ -364,7 +364,7 @@ export const isGameAlreadyPlayed = async (
   if (error) {
     return false;
   }
-  console.log("is game already played reponse", data);
+  console.log("is game already played response", data);
   return !!data;
 };
 

--- a/apps/web/src/phaser/scenes/main.ts
+++ b/apps/web/src/phaser/scenes/main.ts
@@ -1003,7 +1003,7 @@ export class MainScene extends Scene {
     let partInSeconds: number | string = seconds % 60;
     // Adds left zeros to seconds
     partInSeconds = partInSeconds.toString().padStart(2, "0");
-    // Returns formated time
+    // Returns formatted time
     return `${minutes}:${partInSeconds}`;
   }
 


### PR DESCRIPTION
This PR fixes two minor typos:
- Corrects "reponse" to "response" in the console.log message in supabase-queries.ts
- Corrects "formated" to "formatted" in the comment in phaser/scenes/main.ts

These changes improve code readability and consistency.